### PR TITLE
Fix loader customization props

### DIFF
--- a/src/components/NexLoader/NexLoader.scss
+++ b/src/components/NexLoader/NexLoader.scss
@@ -1,15 +1,16 @@
+
 .nex-loader {
     animation: rotate 2s linear infinite;
     z-index: 2;
     position: absolute;
     top: 51.5%;
     left: 48%;
-    width: 50px;
-    height: 50px;
+    width: var(--nex-loader-size, 50px);
+    height: var(--nex-loader-size, 50px);
 
     .path {
         fill: none;
-        stroke: rgba($color: #7d7d7d, $alpha: 1.0);
+        stroke: var(--nex-loader-color, rgba($color: #7d7d7d, $alpha: 1.0));
         stroke-width: 6;
         stroke-linecap: round;
         animation: dash 1.5s ease-in-out infinite;

--- a/src/components/NexLoader/NexLoader.tsx
+++ b/src/components/NexLoader/NexLoader.tsx
@@ -11,9 +11,20 @@ import "./NexLoader.scss"
  * @param {string} [color] - The color of the loader circle.
  */
 const NexLoader: React.FC<NexLoaderProps> = ({ size, color }) => {
+  const style: React.CSSProperties = {};
+
+  if (size) {
+    style["--nex-loader-size" as any] =
+      typeof size === "number" ? `${size}px` : size;
+  }
+
+  if (color) {
+    style["--nex-loader-color" as any] = color;
+  }
+
   return (
-    <svg className="nex-loader" viewBox="0 0 50 50">
-        <circle className="path" cx="25" cy="25" r="20" />
+    <svg className="nex-loader" viewBox="0 0 50 50" style={style}>
+      <circle className="path" cx="25" cy="25" r="20" />
     </svg>
   );
 };

--- a/src/components/NexLoader/NexLoader.types.ts
+++ b/src/components/NexLoader/NexLoader.types.ts
@@ -1,4 +1,6 @@
 export type NexLoaderProps = {
-    size?: string;
+    /** Size of the loader (e.g., `40px` or `2rem`). */
+    size?: string | number;
+    /** Stroke color of the loader circle. */
     color?: string;
-}
+};


### PR DESCRIPTION
## Summary
- allow custom size and color on NexLoader
- use CSS variables in loader styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862edc4981c83338e3f0ba38b140c23